### PR TITLE
Leafref Panic Fix

### DIFF
--- a/pkg/schema/container.go
+++ b/pkg/schema/container.go
@@ -22,7 +22,7 @@ import (
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
 )
 
-func containerFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.ContainerSchema, error) {
+func (sc *Schema) containerFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.ContainerSchema, error) {
 	c := &sdcpb.ContainerSchema{
 		Name:              e.Name,
 		Namespace:         e.Namespace().Name,
@@ -64,7 +64,7 @@ func containerFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.ContainerSchema, 
 		case child.IsDir():
 			c.Children = append(c.Children, child.Name)
 		case child.IsLeaf(), child.IsLeafList():
-			o, err := SchemaElemFromYEntry(child, withDesc)
+			o, err := sc.SchemaElemFromYEntry(child, withDesc)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/schema/leaf.go
+++ b/pkg/schema/leaf.go
@@ -130,8 +130,6 @@ func (sc *Schema) toSchemaType(e *yang.Entry, yt *yang.YangType) (*sdcpb.SchemaL
 		if err != nil {
 			return nil, err
 		}
-		lsePath := leafSchemaEntry.Path()
-		_ = lsePath
 		slt.LeafrefTargetType, err = sc.toSchemaType(leafSchemaEntry, leafSchemaEntry.Type)
 		if err != nil {
 			return nil, err

--- a/pkg/schema/leaf_list.go
+++ b/pkg/schema/leaf_list.go
@@ -19,8 +19,8 @@ import (
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
 )
 
-func leafListFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.LeafListSchema, error) {
-	entryType, err := toSchemaType(e, e.Type)
+func (sc *Schema) leafListFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.LeafListSchema, error) {
+	entryType, err := sc.toSchemaType(e, e.Type)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema/object.go
+++ b/pkg/schema/object.go
@@ -25,10 +25,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func SchemaElemFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.SchemaElem, error) {
+func (sc *Schema) SchemaElemFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.SchemaElem, error) {
 	switch {
 	case e.IsLeaf():
-		leaf, err := leafFromYEntry(e, withDesc)
+		leaf, err := sc.leafFromYEntry(e, withDesc)
 		if err != nil {
 			return nil, err
 		}
@@ -38,7 +38,7 @@ func SchemaElemFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.SchemaElem, erro
 			},
 		}, nil
 	case e.IsLeafList():
-		leaflist, err := leafListFromYEntry(e, withDesc)
+		leaflist, err := sc.leafListFromYEntry(e, withDesc)
 		if err != nil {
 			return nil, err
 		}
@@ -48,7 +48,7 @@ func SchemaElemFromYEntry(e *yang.Entry, withDesc bool) (*sdcpb.SchemaElem, erro
 			},
 		}, nil
 	default:
-		container, err := containerFromYEntry(e, withDesc)
+		container, err := sc.containerFromYEntry(e, withDesc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/store/memstore/memstore.go
+++ b/pkg/store/memstore/memstore.go
@@ -60,7 +60,7 @@ func (s *memStore) GetSchema(ctx context.Context, req *sdcpb.GetSchemaRequest) (
 	if err != nil {
 		return nil, err
 	}
-	schemElem, err := schema.SchemaElemFromYEntry(e, req.GetWithDescription())
+	schemElem, err := sc.SchemaElemFromYEntry(e, req.GetWithDescription())
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func (s *memStore) GetSchemaElements(ctx context.Context, req *sdcpb.GetSchemaRe
 				if !ok {
 					return
 				}
-				schemElem, err := schema.SchemaElemFromYEntry(e, req.GetWithDescription())
+				schemElem, err := sc.SchemaElemFromYEntry(e, req.GetWithDescription())
 				if err != nil {
 					log.Errorf("failed getting entries from schema: %v", err)
 				}

--- a/pkg/store/persiststore/persiststore.go
+++ b/pkg/store/persiststore/persiststore.go
@@ -569,7 +569,7 @@ func (s *persistStore) addSchemaElem(wb *badger.WriteBatch, sc *schema.Schema, e
 	// build entry key
 	key := buildEntryKey(store.Key(sc), getEntryPath(e))
 	// get entry proto
-	se, err := schema.SchemaElemFromYEntry(e, true)
+	se, err := sc.SchemaElemFromYEntry(e, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This aims to prevent a panic when leafref lookups fail. It uses the GetEntry function on the schema instead of the find on an Entry.