### PR TITLE
GetEntry fixes, key ordering, path manipulation fixes

### DIFF
--- a/pkg/schema/object.go
+++ b/pkg/schema/object.go
@@ -251,8 +251,16 @@ func (sc *Schema) buildPath(pe []string, p *sdcpb.Path, e *yang.Entry) error {
 		return sc.buildPath(pe[count:], p, ee)
 	case e.IsChoice():
 		p.Elem = append(p.Elem, cpe)
-		if ee, ok := e.Dir[pe[0]]; ok {
-			return sc.buildPath(pe[1:], p, ee)
+		for _, entry := range e.Dir {
+			if entry.IsCase() {
+				if ee, ok := entry.Dir[pe[0]]; ok {
+					return sc.buildPath(pe[1:], p, ee)
+				}
+			} else {
+				if ee, ok := e.Dir[pe[0]]; ok {
+					return sc.buildPath(pe[1:], p, ee)
+				}
+			}
 		}
 		return fmt.Errorf("choice %s - unknown element %s", e.Name, pe[0])
 	case e.IsCase():

--- a/pkg/schema/object.go
+++ b/pkg/schema/object.go
@@ -90,6 +90,12 @@ func (sc *Schema) GetEntry(pe []string) (*yang.Entry, error) {
 		}
 		log.Debugf("looking up path %s in module %s caused: %v. continuing to search in %v", strings.Join(pe, "/"), mod.Name, err, remainingMods)
 	}
+
+	// if we are here we have not found a path, maybe we have a module name
+	// if we have one module and one path element, likely a module return this
+	if len(mods) == 1 && len(pe) == 1 && mods[0].Name == pe[0] {
+		return mods[0], nil
+	}
 	return nil, fmt.Errorf("schema entry %q not found", strings.Join(pe, "/"))
 }
 

--- a/pkg/schema/references.go
+++ b/pkg/schema/references.go
@@ -157,10 +157,10 @@ func relativeToAbsPath(p *sdcpb.Path, e *yang.Entry) *sdcpb.Path {
 		}
 		if pe.Name == ".." {
 			// fmt.Println("relative path @E", ce.Name, e.IsCase(), e.IsChoice())
+			ce = ce.Parent
 			for (ce.IsCase() || ce.IsChoice()) && ce.Parent != nil {
 				ce = ce.Parent.Parent
 			}
-			ce = ce.Parent
 			continue
 		}
 		// fmt.Println("ce | np", ce.Name, np)


### PR DESCRIPTION
This PR addresses a few issues regarding schema loading:
- Entry lookups where cases do not have the name of the child
- Improved/Refactored module lookups for GetEntry
- getentry fixes in case a prefix is a part of the path
- buildpath fixes for choicecases
- path resolution fixed for some paths where a choicecase would erroneously be part of the path