### PR TITLE
Badgerdb with readonly and proper close

### DIFF
--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -41,6 +41,7 @@ type SchemaPersistStoreCacheConfig struct {
 	TTL             time.Duration `yaml:"ttl,omitempty" json:"ttl,omitempty"`
 	Capacity        uint64        `yaml:"capacity,omitempty" json:"capacity,omitempty"`
 	WithDescription bool          `yaml:"with-description,omitempty" json:"with-description,omitempty"`
+	ReadOnly        bool          `yaml:"read-only,omitempty" json:"read-only,omitempty"`
 }
 
 type SchemaConfig struct {

--- a/pkg/store/memstore/memstore.go
+++ b/pkg/store/memstore/memstore.go
@@ -78,6 +78,14 @@ func (s *memStore) HasSchema(scKey store.SchemaKey) bool {
 	return ok
 }
 
+func (s *memStore) Close() error {
+	return nil
+}
+
+func (s *memStore) IsReadOnly() bool {
+	return false
+}
+
 func (s *memStore) ListSchema(ctx context.Context, req *sdcpb.ListSchemaRequest) (*sdcpb.ListSchemaResponse, error) {
 	s.ms.RLock()
 	defer s.ms.RUnlock()

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -39,6 +39,8 @@ func Key(s *schema.Schema) SchemaKey {
 }
 
 type Store interface {
+	IsReadOnly() bool
+
 	HasSchema(scKey SchemaKey) bool
 	ListSchema(ctx context.Context, req *sdcpb.ListSchemaRequest) (*sdcpb.ListSchemaResponse, error)
 	GetSchemaDetails(ctx context.Context, req *sdcpb.GetSchemaDetailsRequest) (*sdcpb.GetSchemaDetailsResponse, error)
@@ -46,6 +48,7 @@ type Store interface {
 	ReloadSchema(ctx context.Context, req *sdcpb.ReloadSchemaRequest) (*sdcpb.ReloadSchemaResponse, error)
 	DeleteSchema(ctx context.Context, req *sdcpb.DeleteSchemaRequest) (*sdcpb.DeleteSchemaResponse, error)
 	AddSchema(sc *schema.Schema) error
+	Close() error
 
 	GetSchema(ctx context.Context, req *sdcpb.GetSchemaRequest) (*sdcpb.GetSchemaResponse, error)
 	GetSchemaElements(ctx context.Context, req *sdcpb.GetSchemaRequest) (chan *sdcpb.SchemaElem, error)


### PR DESCRIPTION
Allow the badgerdb to be opend readonly, which allows for concurrent access to it. Also add a proper close(), such that the files are in a consistent state when closing.