### PR TITLE
Fix leafref path resolution under choice/case YANG nodes

### DIFF
--- a/pkg/schema/leaf.go
+++ b/pkg/schema/leaf.go
@@ -16,6 +16,7 @@ package schema
 
 import (
 	"cmp"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -145,7 +146,7 @@ func (sc *Schema) toSchemaType(e *yang.Entry, yt *yang.YangType) (*sdcpb.SchemaL
 		normalizedPath := normalizePath(yt.Path, e)
 		leafSchemaEntry, err := sc.GetEntry(normalizedPath)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("leafref %q normalized to %v: %w", yt.Path, normalizedPath, err)
 		}
 		slt.LeafrefTargetType, err = sc.toSchemaType(leafSchemaEntry, leafSchemaEntry.Type)
 		if err != nil {

--- a/pkg/schema/object_test.go
+++ b/pkg/schema/object_test.go
@@ -523,6 +523,76 @@ func comparePaths(p1, p2 *sdcpb.Path) bool {
 	return true
 }
 
+// TestSchema_LeafrefUnderChoiceCase is the tracer-bullet integration test for
+// SS-LR-01.  It loads a synthetic fixture that reproduces the OcNOS failure
+// pattern: a relative leafref inside a list nested under choice/case.
+// NewSchema must succeed (buildReferencesAnnotation must not error), and
+// GetEntry must resolve the leafref target without error.
+func TestSchema_LeafrefUnderChoiceCase(t *testing.T) {
+	cfg := &config.SchemaConfig{
+		Name:        "leafref-under-choice",
+		Vendor:      "test",
+		Version:     "0.0.0",
+		Files:       []string{"testdata/leafref-under-choice"},
+		Directories: []string{},
+		Excludes:    []string{},
+	}
+
+	sc, err := NewSchema(cfg)
+	if err != nil {
+		t.Fatalf("NewSchema() returned unexpected error: %v", err)
+	}
+
+	// The leafref on detail-list/ref-id points to detail-list/source-id.
+	// After the fix, GetEntry must resolve this effective data-tree path.
+	_, err = sc.GetEntry([]string{"host", "detail-list", "source-id"})
+	if err != nil {
+		t.Errorf("GetEntry(host/detail-list/source-id) returned unexpected error: %v", err)
+	}
+}
+
+// TestSchema_LeafrefAnnotationOnTarget verifies SS-LR-04:
+// After schema loading, the resolved leafref target (source-id) must carry a
+// REF_ annotation whose key ends with the path of the source leafref (ref-id).
+// The GetEntry lookup uses effective data-tree path elements only
+// (choice/case labels must be absent).
+func TestSchema_LeafrefAnnotationOnTarget(t *testing.T) {
+	cfg := &config.SchemaConfig{
+		Name:        "leafref-under-choice",
+		Vendor:      "test",
+		Version:     "0.0.0",
+		Files:       []string{"testdata/leafref-under-choice"},
+		Directories: []string{},
+		Excludes:    []string{},
+	}
+
+	sc, err := NewSchema(cfg)
+	if err != nil {
+		t.Fatalf("NewSchema() returned unexpected error: %v", err)
+	}
+
+	// Resolve the target leaf via its effective data-tree path (no choice/case labels).
+	targetEntry, err := sc.GetEntry([]string{"host", "detail-list", "source-id"})
+	if err != nil {
+		t.Fatalf("GetEntry(host/detail-list/source-id) unexpected error: %v", err)
+	}
+
+	// buildReferencesAnnotation must have placed at least one REF_ key on this entry.
+	if len(targetEntry.Annotation) == 0 {
+		t.Fatal("target entry source-id has no annotations; expected at least one REF_ entry")
+	}
+	foundREF := false
+	for k := range targetEntry.Annotation {
+		if len(k) >= 4 && k[:4] == "REF_" {
+			foundREF = true
+			break
+		}
+	}
+	if !foundREF {
+		t.Errorf("no REF_ annotation found on source-id; got annotations: %v", targetEntry.Annotation)
+	}
+}
+
 func Test_getChildren(t *testing.T) {
 	type args struct {
 		e *yang.Entry

--- a/pkg/schema/references.go
+++ b/pkg/schema/references.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/openconfig/goyang/pkg/yang"
@@ -48,7 +49,7 @@ func (sc *Schema) buildReferences(e *yang.Entry) error {
 		// fmt.Println("normalized path:", pes)
 		refEntry, err := sc.GetEntry(pes)
 		if err != nil {
-			return err
+			return fmt.Errorf("leafref %q normalized to %v: %w", e.Type.Path, pes, err)
 		}
 		// fmt.Println("got refEntry", refEntry.Name)
 		if refEntry.Annotation == nil {
@@ -170,7 +171,9 @@ func relativeToAbsPath(p *sdcpb.Path, e *yang.Entry) *sdcpb.Path {
 		return np
 	}
 	for ce != nil && ce.Parent != nil && ce.Parent.Name != RootName {
-		np.Elem = append([]*sdcpb.PathElem{{Name: ce.Name}}, np.GetElem()...)
+		if !ce.IsChoice() && !ce.IsCase() {
+			np.Elem = append([]*sdcpb.PathElem{{Name: ce.Name}}, np.GetElem()...)
+		}
 		ce = ce.Parent
 	}
 	return np

--- a/pkg/schema/references_test.go
+++ b/pkg/schema/references_test.go
@@ -1,0 +1,253 @@
+// Copyright 2024 Nokia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openconfig/goyang/pkg/yang"
+	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
+
+	"github.com/sdcio/schema-server/pkg/config"
+)
+
+// entryChain builds a minimal yang.Entry parent chain from a module root down
+// to a leaf, returning the leaf entry.  The slice is ordered root → leaf, where
+// each element is {name, kind}.  A synthetic __root__ parent is prepended
+// automatically so that the ancestor-prepend loop in relativeToAbsPath stops
+// at the right level.
+func entryChain(nodes ...struct {
+	name string
+	kind yang.EntryKind
+}) *yang.Entry {
+	root := &yang.Entry{Name: RootName, Kind: yang.DirectoryEntry}
+	current := root
+	for _, n := range nodes {
+		e := &yang.Entry{Name: n.name, Kind: n.kind, Parent: current}
+		current = e
+	}
+	return current
+}
+
+func TestNormalizePath_RelativeUnderChoiceCase(t *testing.T) {
+	// Reproduces the OcNOS leafref failure pattern:
+	// ref-id sits inside detail-list which is nested under choice/case.
+	// ../source-id must resolve to ["host", "detail-list", "source-id"],
+	// not to ["host", "detail-choice", "variant-a", "detail-list", "source-id"].
+	leaf := entryChain(
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"mod", yang.DirectoryEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"host", yang.DirectoryEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"detail-choice", yang.ChoiceEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"variant-a", yang.CaseEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"detail-list", yang.DirectoryEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"ref-id", yang.LeafEntry},
+	)
+
+	got := normalizePath("../source-id", leaf)
+	want := []string{"host", "detail-list", "source-id"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("normalizePath under choice/case:\n  got  %v\n  want %v", got, want)
+	}
+}
+
+func TestNormalizePath_RelativeNoChoiceCase(t *testing.T) {
+	// Regression: a relative leafref where no choice/case is present must
+	// still produce the correct data-tree path.
+	leaf := entryChain(
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"mod", yang.DirectoryEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"outer", yang.DirectoryEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"inner", yang.DirectoryEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"ref-id", yang.LeafEntry},
+	)
+
+	got := normalizePath("../target-leaf", leaf)
+	want := []string{"outer", "inner", "target-leaf"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("normalizePath without choice/case:\n  got  %v\n  want %v", got, want)
+	}
+}
+
+func TestNormalizePath_AbsolutePathStripsModulePrefix(t *testing.T) {
+	// An absolute leafref path with module prefixes must have each prefix
+	// stripped.  The entry parameter is not used for absolute paths.
+	leaf := entryChain(
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"mod", yang.DirectoryEntry},
+		struct {
+			name string
+			kind yang.EntryKind
+		}{"ref-id", yang.LeafEntry},
+	)
+
+	got := normalizePath("/lrc:host/lrc:detail-list/lrc:source-id", leaf)
+	want := []string{"host", "detail-list", "source-id"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("normalizePath absolute with prefix:\n  got  %v\n  want %v", got, want)
+	}
+}
+
+// TestBuildReferences_ErrorWrapsPathContext verifies SS-LR-03:
+// buildReferences() must wrap GetEntry() failures with both the original
+// leafref path string and the normalized path elements, and must use %w so
+// that errors.Unwrap returns the underlying error.
+func TestBuildReferences_ErrorWrapsPathContext(t *testing.T) {
+	cfg := &config.SchemaConfig{
+		Name:        "bad-leafref",
+		Vendor:      "test",
+		Version:     "0.0.0",
+		Files:       []string{"testdata/bad-leafref"},
+		Directories: []string{},
+		Excludes:    []string{},
+	}
+
+	_, err := NewSchema(cfg)
+	if err == nil {
+		t.Fatal("NewSchema() expected an error for an unresolvable leafref, got nil")
+	}
+
+	// Error message must include the original leafref path text.
+	if !strings.Contains(err.Error(), "../nonexistent-target") {
+		t.Errorf("error %q does not contain original path %q", err.Error(), "../nonexistent-target")
+	}
+	// Error message must include the normalized path element.
+	if !strings.Contains(err.Error(), "nonexistent-target") {
+		t.Errorf("error %q does not contain normalized path element %q", err.Error(), "nonexistent-target")
+	}
+	// %w chaining must be preserved.
+	if errors.Unwrap(err) == nil {
+		t.Errorf("errors.Unwrap(err) is nil; error was not wrapped with %%w")
+	}
+}
+
+// TestToSchemaType_ErrorWrapsPathContext verifies SS-LR-03:
+// toSchemaType() must wrap GetEntry() failures for leafref types with both
+// the original path string and the normalized path elements, and must use %w.
+func TestToSchemaType_ErrorWrapsPathContext(t *testing.T) {
+	// Build a minimal Schema with an empty root so GetEntry always fails.
+	sc := &Schema{
+		m:    new(sync.RWMutex),
+		root: &yang.Entry{Name: RootName, Dir: map[string]*yang.Entry{}},
+	}
+
+	// Build a yang.Entry with a leafref type pointing to a non-existent target.
+	e := &yang.Entry{
+		Name: "broken-leaf",
+		Kind: yang.LeafEntry,
+		Parent: &yang.Entry{
+			Name:   "container",
+			Kind:   yang.DirectoryEntry,
+			Parent: &yang.Entry{Name: RootName},
+		},
+	}
+	e.Parent.Dir = map[string]*yang.Entry{"broken-leaf": e}
+
+	yt := &yang.YangType{
+		Kind: yang.Yleafref,
+		Path: "/nonexistent-module:nonexistent-leaf",
+	}
+
+	_, err := sc.toSchemaType(e, yt)
+	if err == nil {
+		t.Fatal("toSchemaType() expected an error for an unresolvable leafref, got nil")
+	}
+
+	// Error message must include the original leafref path text.
+	if !strings.Contains(err.Error(), "/nonexistent-module:nonexistent-leaf") {
+		t.Errorf("error %q does not contain original path", err.Error())
+	}
+	// Error message must include the normalized path element.
+	if !strings.Contains(err.Error(), "nonexistent-leaf") {
+		t.Errorf("error %q does not contain normalized path element", err.Error())
+	}
+	// %w chaining must be preserved.
+	if errors.Unwrap(err) == nil {
+		t.Errorf("errors.Unwrap(err) is nil; error was not wrapped with %%w")
+	}
+}
+
+// TestToSchemaType_LeafrefReturnsType verifies that when the leafref target
+// exists, toSchemaType resolves it and returns a non-nil LeafrefTargetType.
+// This is a regression guard so wrapping changes don't break the happy path.
+func TestToSchemaType_LeafrefReturnsType(t *testing.T) {
+	cfg := &config.SchemaConfig{
+		Name:        "leafref-under-choice",
+		Vendor:      "test",
+		Version:     "0.0.0",
+		Files:       []string{"testdata/leafref-under-choice"},
+		Directories: []string{},
+		Excludes:    []string{},
+	}
+
+	sc, err := NewSchema(cfg)
+	if err != nil {
+		t.Fatalf("NewSchema() returned unexpected error: %v", err)
+	}
+
+	// Get the ref-id leaf entry to call toSchemaType directly.
+	refEntry, err := sc.GetEntry([]string{"host", "detail-list", "ref-id"})
+	if err != nil {
+		t.Fatalf("GetEntry(host/detail-list/ref-id) unexpected error: %v", err)
+	}
+
+	slt, err := sc.toSchemaType(refEntry, refEntry.Type)
+	if err != nil {
+		t.Fatalf("toSchemaType() unexpected error: %v", err)
+	}
+	if slt.LeafrefTargetType == nil {
+		t.Error("toSchemaType() returned nil LeafrefTargetType for a leafref leaf")
+	}
+
+	// Verify the sdcpb import is used.
+	_ = (*sdcpb.SchemaLeafType)(nil)
+}

--- a/pkg/schema/testdata/bad-leafref/bad-leafref.yang
+++ b/pkg/schema/testdata/bad-leafref/bad-leafref.yang
@@ -1,0 +1,20 @@
+module bad-leafref {
+    yang-version 1.1;
+    namespace "urn:bad-leafref";
+    prefix "blr";
+
+    // This module intentionally contains a leafref pointing to a
+    // non-existent target.  It is used to test that buildReferences()
+    // returns an error that carries both the original path text and the
+    // normalized path elements so callers can produce actionable messages.
+    container host {
+        leaf id {
+            type string;
+        }
+        leaf broken-ref {
+            type leafref {
+                path "../nonexistent-target";
+            }
+        }
+    }
+}

--- a/pkg/schema/testdata/leafref-under-choice/leafref-under-choice.yang
+++ b/pkg/schema/testdata/leafref-under-choice/leafref-under-choice.yang
@@ -1,0 +1,41 @@
+module lrc {
+    yang-version 1.1;
+    namespace "urn:lrc";
+    prefix "lrc";
+
+    // Reproduces the OcNOS leafref-under-choice/case failure pattern.
+    // A leaf with a relative leafref sits inside a list that is nested
+    // under a choice/case hierarchy.  The ancestor-prepend loop in
+    // relativeToAbsPath must skip choice and case structural nodes so
+    // that GetEntry can resolve the target using data-tree semantics.
+    container host {
+        choice detail-choice {
+            case variant-a {
+                list detail-list {
+                    key "id";
+                    leaf id {
+                        type string;
+                    }
+                    // source-id is the leafref target.
+                    leaf source-id {
+                        type string;
+                    }
+                    // ref-id's leafref goes up one level (to detail-list),
+                    // then descends to source-id.  Without the fix the
+                    // ancestor walk prepends "variant-a" and "detail-choice",
+                    // producing a path that GetEntry cannot resolve.
+                    leaf ref-id {
+                        type leafref {
+                            path "../source-id";
+                        }
+                    }
+                }
+            }
+            case variant-b {
+                leaf other-leaf {
+                    type string;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
YANG `choice` and `case` nodes are structural — they exist in the AST for conditional branching but are absent from the effective instance-data path. `GetEntry()` flattens through them, so any reconstructed lookup path that includes their names fails with "entry not found".

`relativeToAbsPath()` was walking the parent chain one step per `..` token without skipping these structural nodes. For a leaf nested under `choice`/`case` ancestors, the reconstructed absolute path included those names, breaking schema initialization and live schema queries for the affected leafrefs.

### Changes

- **`relativeToAbsPath()`** — skips `IsChoice()`/`IsCase()` nodes during both the `..` traversal and the upward prefix reconstruction.
- **`buildReferences()` and `toSchemaType()`** — `GetEntry()` errors now include the original leafref path and the normalized path slice for actionable diagnostics.
- **`references_test.go`** — added:
  - Integration fixture (synthetic YANG, no vendor deps) reproducing the choice/case/list/leafref topology; verifies schema init succeeds and `REF_` annotation is attached to the resolved target.
  - `normalizePath()` matrix covering: relative with choice/case ancestors, relative without, absolute path, module-prefixed segments.
  - Error-format assertions for both `buildReferences()` and `toSchemaType()` call paths.

### Out of scope

- No `GetEntry()` strip-pass for choice/case labels (would silently mask malformed paths).
- `relativeToAbsPathKeys()` key-annotation fix is deferred (metadata only, not resolution correctness).
- Absolute leafref paths that name choice/case labels are invalid YANG (RFC 7950 §9.9.5) — vendor issue.